### PR TITLE
use Base64#strict_encode64 when signing requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2
+  - 2.3
 
 script: bundle exec rspec

--- a/lib/ey-hmac/adapter.rb
+++ b/lib/ey-hmac/adapter.rb
@@ -37,7 +37,7 @@ class Ey::Hmac::Adapter
   # @param [String] signature digest hash function. Defaults to #sign_with
   # @return [String] HMAC signature of {#request}
   def signature(key_secret, digest = self.sign_with)
-    Base64.encode64(
+    Base64.strict_encode64(
       OpenSSL::HMAC.digest(
         OpenSSL::Digest.new(digest.to_s), key_secret, canonicalize)).strip
   end


### PR DESCRIPTION
Use an updated Base64 implementation.

See:
* https://ruby-doc.org/stdlib-2.3.1/libdoc/base64/rdoc/Base64.html
* https://www.ietf.org/rfc/rfc2045.txt
* https://tools.ietf.org/html/rfc4648#section-5

Fixes #4