### PR TITLE
Fix default_adapter method

### DIFF
--- a/lib/ey-hmac.rb
+++ b/lib/ey-hmac.rb
@@ -23,12 +23,10 @@ module Ey
     end
 
     def self.default_adapter
-      @default_adapter ||= begin
-                             if defined?(Rack) || defined?(Rails)
-                               Ey::Hmac::Adapter::Rack
-                             elsif defined?(Faraday)
-                               Ey::Hmac::Adapter::Rails
-                             end
+      @default_adapter ||= if defined?(::Rack) || defined?(::Rails)
+                             Ey::Hmac::Adapter::Rack
+                           elsif defined?(::Faraday)
+                             Ey::Hmac::Adapter::Faraday
                            end
     end
 


### PR DESCRIPTION
Hi,

I've noticed an issue with auto-detecting Faraday.

When checking for unprefixed `defined?(Rack)` ruby will try local scope
first, causing the autoload and thus passing the test. Which itself will
load Adapter that does `require 'rack'`. Meaning that Faraday adapter
will never be used and `rack` will get auto-required even if you're not using it.